### PR TITLE
build: upgrade Spring Boot to 3.5.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version>
+        <version>3.5.15</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -47,8 +47,6 @@
         <!--provide default empty argLine for surefire, is overridden by jacoco -->
         <argLine/>
 
-        <!-- dependencies -->
-        <tomcat.version>10.1.55</tomcat.version> <!-- override spring boot, may be removed once spring boot ships this version or newer (stay on 10.1.x — Spring Boot 3.5 targets Servlet 6.0, Tomcat 11 requires Servlet 6.1) -->
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- Bump Spring Boot from 3.5.14 to 3.5.15 (latest 3.5.x patch).
- Drop `tomcat.version` override — Spring Boot 3.5.15 now manages 10.1.55.

## Test plan
- [ ] CI passes